### PR TITLE
動画の読み込みをRust側に移行する 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@
 | `lint`    | コードリント                           |
 | `bundle`  | デスクトップアプリケーションのバンドル |
 
+### ⚠️アプリケーションのバンドルについて
+
+このアプリケーションはWindowsの実行ファイルを想定しています。  
+そのためmacでバンドルする場合は、[こちらの公式ドキュメント](https://v2.tauri.app/ja/distribute/windows-installer/#experimental-build-windows-apps-on-linux-and-macos)を参考に必要なライブラリをインストールしてからバンドルしてください（また、まだexperimentalである（執筆当時）ことに注意してください）。  
+また、npm scriptを実行してもバンドルできない場合は、以下のコマンドを実行してみてください。
+
+```zsh
+npm run tauri build -- --runner cargo-xwin --target x86_64-pc-windows-msvc
+```
+
 ## 📚 ライブラリ・フレームワークのインストール
 
 ```zsh

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vid-ap-play",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4693,7 +4693,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vid-ap-play"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "mp4parse",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4581,6 +4581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "urlpattern"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4644,6 +4650,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-opener",
  "tauri-plugin-store",
+ "urlencoding",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +313,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1006,6 +1027,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible_collections"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
+dependencies = [
+ "hashbrown 0.13.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1520,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2143,6 +2182,20 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mp4parse"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a35203d3c6ce92d5251c77520acb2e57108c88728695aa883f70023624c570"
+dependencies = [
+ "bitreader",
+ "byteorder",
+ "fallible_collections",
+ "log",
+ "num-traits",
+ "static_assertions",
 ]
 
 [[package]]
@@ -4642,6 +4695,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vid-ap-play"
 version = "0.1.0"
 dependencies = [
+ "mp4parse",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,4 +26,5 @@ tauri-plugin-store = "2"
 tauri-plugin-dialog = "2.0.0"
 tauri-plugin-fs = "2"
 urlencoding = "2.1"
+mp4parse = "0.17.0"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@ name = "vid-ap-play"
 version = "1.1.0"
 description = "A Video App"
 authors = ["trancore"]
-edition = "2025"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,4 +25,5 @@ serde_json = "1"
 tauri-plugin-store = "2"
 tauri-plugin-dialog = "2.0.0"
 tauri-plugin-fs = "2"
+urlencoding = "2.1"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "vid-ap-play"
-version = "0.1.0"
-description = "A Tauri App"
-authors = ["you"]
-edition = "2021"
+version = "1.1.0"
+description = "A Video App"
+authors = ["trancore"]
+edition = "2025"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,11 +1,53 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use std::io::BufReader;
+use std::fs::File;
+use mp4parse::read_mp4;
+use urlencoding::decode;
+
+#[tauri::command]
+fn get_duration(path: &str)-> f64 {
+    let decoded_path = decode(path).expect("UTF-8");
+    let local_path = std::path::Path::new(decoded_path.as_ref());
+
+    let mut result_duration: f64 = 0.0;
+
+    if local_path.exists() && local_path.is_file() {
+        let file = match File::open(local_path) {
+            Ok(file) => file,
+            Err(_) => {
+                println!("Failed to open file: {}", local_path.display());
+                return 0.0;
+            }
+        };        
+        let mut reader = BufReader::new(file);
+        let context = match read_mp4(&mut reader) {
+            Ok(context) => context,
+            Err(_) => {
+                println!("Failed to read file: {}", local_path.display());
+                return 0.0;
+            }
+        };        
+    
+        for track in &context.tracks {
+            if let Some(duration) = track.duration {
+                if let Some(timescale) = track.timescale {
+                    result_duration = duration.0 as f64 / timescale.0 as f64;
+                    break;
+                }
+            }
+        }
+    }
+    result_duration    
+}
+
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_store::Builder::default().build())
+        .invoke_handler(tauri::generate_handler![get_duration])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "vid-ap-play",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "identifier": "com.vid-ap-play.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/Ui/Tab/ContentTab.tsx
+++ b/src/components/Ui/Tab/ContentTab.tsx
@@ -1,4 +1,5 @@
 ﻿import { convertFileSrc } from '@tauri-apps/api/core'
+import { invoke } from '@tauri-apps/api/core'
 import { readDir } from '@tauri-apps/plugin-fs'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Button from '~/components/Common/Button/Button'
@@ -32,17 +33,14 @@ export default function ContentTab({
     const currentFiles = readFiles
       .filter((file) => VIDEO_EXTENSIONS.some((ext) => file.name.endsWith(ext)))
       .map<Promise<IFile>>(async (file) => {
-        const src = convertFileSrc(currentTab.path + '/' + file.name)
-        const videoElement = document.createElement('video')
-        videoElement.src = src
-        const duration = await new Promise<number>((resolve) => {
-          videoElement.addEventListener('loadedmetadata', () => {
-            resolve(videoElement.duration)
-          })
+        const srcPath = currentTab.path + '/' + file.name
+
+        const duration = await invoke<number>('get_duration', {
+          path: srcPath,
         })
 
         return {
-          src: src,
+          src: convertFileSrc(srcPath),
           fileName: file.name,
           duration: duration,
         }

--- a/src/components/Ui/Tab/ToggleTab.tsx
+++ b/src/components/Ui/Tab/ToggleTab.tsx
@@ -28,7 +28,7 @@ export default function ToggleTab({
                 className={`${tab.active && 'text-orange-700'} w-60 cursor-pointer overflow-hidden border border-gray-500 p-4 text-ellipsis`}
                 onClick={() => onClick.tab(tab.id)}
               >
-                {getLastTextSegment(tab.path, '¥')}
+                {getLastTextSegment(tab.path, '/')}
               </Tab>
             )))}
         <Tab


### PR DESCRIPTION
## 目的

<!-- このP-Rの目的を記載してください -->

動画が多い場合、その表示に時間がかかっていた。
おそらく、動画の再生時間の読み込みに時間がかかっていると考えたため、処理の早いRust側に移行することで、その表示の時間を短縮できると考えました。

## 概要

<!-- このP-Rの概要を記載してください -->

- Rust側への再生時間の読み込みを移行
  - urlencodingの導入
  - mp4parseの導入
  - mp4parseを使って動画の再生時間の取得とフロント側への送信
- READMEの追記

## 共有項目

<!-- このP-Rで共有した項目を記載してください -->

- resolve #6 
